### PR TITLE
prov/sharp: sharp provider can be mocked

### DIFF
--- a/config/fi_provider.m4
+++ b/config/fi_provider.m4
@@ -85,10 +85,12 @@ dnl
 
 	# Check the --enable-<$1> value
 	$1_dl=0
+	$1_mocked=0
 	AS_CASE([$enable_$1],
 	[yes|no], [],
 	[dl],     [enable_$1=yes $1_dl=1],
-	[auto],   [],
+	[mocked], [enable_$1=yes $1_mocked=1],
+	[auto],   [$1_mocked=1],
 	[dl:*],   [FI_CHECK_PREFIX_DIR([${enable_$1:3}], [$1])
 		   enable_$1=yes $1_dl=1],
 	[FI_CHECK_PREFIX_DIR([$enable_$1], [$1])
@@ -130,6 +132,7 @@ dnl
 
 	AC_DEFINE_UNQUOTED([HAVE_]m4_translit([$1], [a-z], [A-Z]), $$1_happy, [$1 provider is built])
 	AC_DEFINE_UNQUOTED([HAVE_]m4_translit([$1], [a-z], [A-Z])[_DL], $$1_dl, [$1 provider is built as DSO])
+	AC_DEFINE_UNQUOTED([HAVE_]m4_translit([$1], [a-z], [A-Z])[_MOCKED], $$1_mocked, [$1 provider is mocked])
 
 	# Set AM conditionals for HAVE_<provider> and HAVE_<provider>_DL
 	# as well as AC defines
@@ -137,6 +140,8 @@ dnl
 		[test $$1_happy -eq 1])
 	AM_CONDITIONAL([HAVE_]m4_translit([$1], [a-z], [A-Z])[_DL],
 		[test $$1_dl -eq 1])
+	AM_CONDITIONAL([HAVE_]m4_translit([$1], [a-z], [A-Z])[_MOCKED],
+		[test $$1_mocked -eq 1])
 
 	# If this provider was specifically requested but we can't
 	# build it, error.

--- a/prov/sharp/Makefile.include
+++ b/prov/sharp/Makefile.include
@@ -1,7 +1,5 @@
 if HAVE_SHARP
 _sharp_files = \
-	prov/sharp/src/mocks/api/sharp.h	\
-	prov/sharp/src/mocks/api/sharp_mocks.c	\
 	include/ofi_sharp.h			\
 	prov/sharp/src/sharp.h			\
 	prov/sharp/src/sharp_attr.c		\
@@ -13,6 +11,14 @@ _sharp_files = \
 	prov/sharp/src/sharp_cq.c		\
 	prov/sharp/src/sharp_coll.c		\
 	prov/sharp/src/sharp_progress.c
+
+if HAVE_SHARP_MOCKED
+_sharp_files += \
+	prov/sharp/src/mocks/api/sharp.h	\
+	prov/sharp/src/mocks/api/sharp_mocks.c
+else !HAVE_SHARP_MOCKED
+sharp_LIBS = -lsharp -lsharp_coll
+endif !HAVE_SHARP_MOCKED
 
 if HAVE_SHARP_DL
 pkglib_LTLIBRARIES += libsharp-fi.la

--- a/prov/sharp/configure.m4
+++ b/prov/sharp/configure.m4
@@ -11,5 +11,14 @@ AC_DEFUN([FI_SHARP_CONFIGURE],[
 	# Determine if we can support the sharp provider
 	sharp_happy=0
 	AS_IF([test x"$enable_sharp" != x"no"], [sharp_happy=1])
+
+	AS_IF([test $sharp_happy -eq 1 && test $sharp_mocked -eq 0],
+	      [AC_CHECK_LIB(sharp_coll, sharp_coll_init, [],
+			AC_MSG_ERROR([The libsharp_coll library not found (set LDFLAGS to point the location)]), [])])
+
+	AS_IF([test $sharp_happy -eq 1 && test $sharp_mocked -eq 0],
+	      [AC_CHECK_LIB(sharp, sharp_init_session, [],
+			AC_MSG_ERROR([The libsharp library not found (set LDFLAGS to point the location)]), [])])
+
         AS_IF([test $sharp_happy -eq 1], [$1], [$2])
 ])


### PR DESCRIPTION
In order to mock SHARP functions run:
```sh
$ ./configure --enable-sharp=mocked
```
or
```sh
$ ./configure --enable-sharp=auto
```

Running:
```sh
$ ./configure --enable-sharp=yes
```
make use of SHARP libraries instead of mocks.

Signed-off-by: Lukasz Dorau <lukasz.dorau@intel.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grom72/libfabric/3)
<!-- Reviewable:end -->
